### PR TITLE
fix:创建时选择非今日的日记转换时间不一致

### DIFF
--- a/lib/1diary.js
+++ b/lib/1diary.js
@@ -18,7 +18,12 @@ function convertNiderijiToOnediary(nideriji) {
   let oneDiaries = [];
   for (let i = 0; i < nideriji.length; i++) {
     const diary = nideriji[i];
-    let day = dayjs(diary.createdtime);
+
+    //fix: 转换非今日日记的问题
+    let created_date_str = diary.createddate;
+    let created_time_str = diary.createdtime?diary.createdtime.slice(10):" 00:00:00+08:00";//截取时间部分
+    let day = dayjs(created_date_str+created_time_str);
+
     let oneDiary = initOnediary();
     oneDiary.uuid = uuidv5(day.valueOf().toString(), MY_NAMESPACE);
     oneDiary.title = diary.title;

--- a/lib/1diary.js
+++ b/lib/1diary.js
@@ -18,7 +18,12 @@ function convertNiderijiToOnediary(nideriji) {
   let oneDiaries = [];
   for (let i = 0; i < nideriji.length; i++) {
     const diary = nideriji[i];
-    let day = dayjs(diary.createdtime);
+
+    //fix: 转换非今日日记的问题
+    let created_date_str = diary.createddate;
+    let created_time_str = diary.createdtime.slice(10)?diary.createdtime.slice(10):" 00:00:00+08:00";//截取时间部分
+    let day = dayjs(created_date_str+created_time_str);
+
     let oneDiary = initOnediary();
     oneDiary.uuid = uuidv5(day.valueOf().toString(), MY_NAMESPACE);
     oneDiary.title = diary.title;


### PR DESCRIPTION
考虑一个场景，你今天突然想起几年前发生的一件很有意思的事，想把它记在日记里。
你可以创建一篇日记，并指定日记日期为几年前发生这件事时的日期。你的日记和一本日记都支持这个功能(创建非今日的日记)。
但是两个软件具体实现细节又略有差别，所以会导致转换时产生问题。
在你的日记中，这篇日记createddate字段是几年前的日期，createdtime字段是今天的日期。在日记软件中，这篇日记的日期显示为createddate字段的日期（几年前的日期）。
在一本日记中，这篇日记有只一个createTime字段，是你选择的几年前的日期的时间戳。日记软件中显示的日期就是这个时间戳中包含的日期（几年前的日期）。
在你的日记转换一本日记过程中，若直接用你的日记中的createdtime字段转换成一本日记的createTime，会导致在一本日记中，这篇日记会显示为今日，而非几年前。

close #6